### PR TITLE
fix: Re-add deprecated Blindfold function

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -24,7 +24,7 @@ fileignoreconfig:
   ignore_detectors:
   - filecontent
 - filename: blindfold/blindfold.go
-  checksum: 9faa562c54a78c595c2a5f342612667cc336e8516f25eb14dd46af87f4691934
+  checksum: 60fbac3eecbb76f102e061a393ad73b648ddc503e2c4882f0e1d61c18950bc59
 - filename: go.sum
   checksum: feaefc13f890541d6f985e9dafd427809892a4df8935520b76f13868ca6125ac
 - filename: public_key.go

--- a/blindfold/blindfold.go
+++ b/blindfold/blindfold.go
@@ -112,6 +112,14 @@ func ExecuteVesctl(ctx context.Context, vesctl string, args []string, params map
 }
 
 // Executes vesctl to blindfold the supplied plaintext using the supplied PublicKey and PolicyDocument, returning the
+// Base64 encoded sealed data.
+// Deprecated: Blindfold function exists for backward compatibility with v1.0.x and should not be used in new code; use
+// Seal or SealFile functions instead.
+func Blindfold(ctx context.Context, vesctl string, plaintext []byte, pubKey *f5xc.PublicKey, policyDoc *f5xc.SecretPolicyDocument) ([]byte, error) {
+	return Seal(ctx, vesctl, plaintext, pubKey, policyDoc)
+}
+
+// Executes vesctl to blindfold the supplied plaintext using the supplied PublicKey and PolicyDocument, returning the
 // Base64 encoded sealed data. The function will write and cleanup temporary files to use as inputs to vesctl, and will
 // use an execution environment that avoids avoid leaking data.
 func Seal(ctx context.Context, vesctl string, plaintext []byte, pubKey *f5xc.PublicKey, policyDoc *f5xc.SecretPolicyDocument) ([]byte, error) {


### PR DESCRIPTION
Release v1.1.0 should have contained a deprecated function for Blindfold that is a wrapper around Seal for backward compatibility.