### PR TITLE
fix: Remove copy of loop variable

### DIFF
--- a/cmd/unseal/main.go
+++ b/cmd/unseal/main.go
@@ -77,7 +77,6 @@ func main() {
 		return
 	}
 	for _, sourceFile := range os.Args[1:] {
-		sourceFile := sourceFile
 		logger := slog.With("sourceFile", sourceFile)
 		logger.Debug("Attempting to retrieve file data")
 		data, err := os.ReadFile(sourceFile)


### PR DESCRIPTION
This module is using go 1.22 semantics and doesn't need the variable copy when looping over command line arguments in unseal application.